### PR TITLE
fix: prevent rerendering in dev mode

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+
+const nextConfig = {
+  reactStrictMode: false,
+};
 
 export default nextConfig;


### PR DESCRIPTION
rerendering 이슈 해결했습니다. 이게 react 18부터 strictmode가 기본인데 이게 자동으로 렌더링을 한 번 더 해주는 기능으로 오류를 잡기 쉽게 해주는 기능이라고 합니다. 프로덕션에서도 한 번 더 렌더링하는거는 아니고, 개발 모드에서만 이렇게 한 번 더 렌더링을 해준다고 합니다. 그래서 이거 해제했어요!